### PR TITLE
ignore prototype properties (for IE8 compat with es5-shim)

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ function hasLength (e) {
 }
 
 function any(ary, test) {
-  for(var i in ary)
+  for(var i=0;i<ary.length;i++)
     if(test(ary[i]))
       return true
   return false


### PR DESCRIPTION
This makes adiff work in IE8 (and I believe also IE7) when using with [es5-shim](https://npmjs.org/package/es5-shim)

Still doesn't make testling pass though. Would need to include es5-shim in the test and either remove or shim the JSON dependency.
