### PR TITLE
fix optimistic diff when b appends identical value

### DIFF
--- a/index.js
+++ b/index.js
@@ -185,7 +185,7 @@ var exports = module.exports = function (deps, exports) {
     var patch = []
     for(var i = 0; i < M; i++)
       if(a[i] !== b[i]) {
-        var cur = [i], deletes = 0
+        var cur = [i,0], deletes = 0
         while(a[i] !== b[i] && i < m) {
           cur[1] = ++deletes
           cur.push(b[i++])

--- a/test/boolean-diff.js
+++ b/test/boolean-diff.js
@@ -1,0 +1,14 @@
+var test = require('tape')
+var d = require('../')
+
+test('boolean diff of different lengths',function(t){
+  var changes = d.diff([true],[true,true])
+  t.deepEqual(changes, [[1,0,true]])
+  t.end()
+})
+
+test('string diff of different lengths',function(t){
+  var changes = d.diff(['A'],['A','A'])
+  t.deepEqual(changes, [[1,0,'A']])
+  t.end()
+})


### PR DESCRIPTION
``` js
// currently:
adiff.diff([true],[true,true]) // => [1,true]
// but should return [1, 0, true]
```

Bug caused by a dodgy code path that doesn't append the deleted count onto array.

This PR should solve the problem!
